### PR TITLE
Feature/typespecs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _build
 ebin
 log/
 rebar.lock
+doc/

--- a/src/tql.erl
+++ b/src/tql.erl
@@ -26,8 +26,8 @@ id(X) ->
 %% ```
 %%    Funs = [fun string:titlecase/1, fun string:reverse/1],
 %%    Res = tql:pipe("this is an example", Funs),
-%%    Res = "elpmaxE nA sI sihT".
-%% '''
+%%    Res = "elpmaxe na si sihT".
+
 -spec pipe(Arg, Funs) -> Res when
     Arg :: term(),
     Funs :: [Fun],

--- a/src/tql.erl
+++ b/src/tql.erl
@@ -27,7 +27,7 @@ id(X) ->
 %%    Funs = [fun string:titlecase/1, fun string:reverse/1],
 %%    Res = tql:pipe("this is an example", Funs),
 %%    Res = "elpmaxe na si sihT".
-
+%% '''
 -spec pipe(Arg, Funs) -> Res when
     Arg :: term(),
     Funs :: [Fun],

--- a/src/tql.erl
+++ b/src/tql.erl
@@ -1,9 +1,7 @@
 -module(tql).
 
 %% API exports
--export([ binary_join/2
-        , id/1
-        , to_hex/1
+-export([ id/1
         , pipe/2
         ]).
 
@@ -11,31 +9,30 @@
 %%% API
 %%%---------------------------------------------------------------------
 
-binary_join([], _Sep) ->
-  <<>>;
-binary_join([Part], _Sep) ->
-  Part;
-binary_join(List, Sep) ->
-  lists:foldr(
-    fun (A, B) ->
-        case bit_size(B) > 0 of
-          true  -> <<A/binary, Sep/binary, B/binary>>;
-          false -> A
-        end
-    end,
-    <<>>,
-    List
-   ).
 
+%% @doc Returns the argument itself.
+%%
+%% This is useful for composition and as a generic helper.
 -spec id(A) -> A.
 id(X) ->
   X.
 
-to_hex(Bin) when is_binary(Bin) ->
-  list_to_binary(
-    lists:flatten(
-      [io_lib:format("~2.16.0b", [B]) || <<B>> <= Bin])).
-
+%% @doc Thread a value through a set of unary functions.
+%%
+%% The first function receives the provided argument as its input, with
+%% its output being passed to the next function, and so on. When the
+%% provided list of functions is empty, this amounts to `id'.
+%%
+%% ```
+%%    Funs = [fun string:titlecase/1, fun string:reverse/1],
+%%    Res = tql:pipe("this is an example", Funs),
+%%    Res = "elpmaxE nA sI sihT".
+%% '''
+-spec pipe(Arg, Funs) -> Res when
+    Arg :: term(),
+    Funs :: [Fun],
+    Fun :: fun ((A :: term()) -> B :: term()),
+    Res :: term().
 pipe(Arg, Fs) ->
   (tql_fun:compose(lists:reverse(Fs)))(Arg).
 

--- a/src/tql_bin.erl
+++ b/src/tql_bin.erl
@@ -3,6 +3,7 @@
 %% API
 
 -export([ to_hex/1
+        , join/2
         ]
        ).
 
@@ -10,8 +11,41 @@
 %%% API
 %%%---------------------------------------------------------------------
 
+
+%% @doc Encodes a binary in hexadecimal.
+%%
+%% ```
+%%    R = tql_bin:to_hex(<<"foobar">>),
+%%    R = <<"666f6f626172">>.
+%% '''
+-spec to_hex(binary()) -> binary().
 to_hex(Bin) when is_binary(Bin) ->
   list_to_binary([io_lib:format("~2.16.0b", [B]) || <<B>> <= Bin]).
+
+%% @doc Joins a list of binaries with a separator.
+%%
+%% ```
+%%    V = tql_bin:join([<<"a">>, <<"b">>, <<"c">>], <<", ">>),
+%%    V = <<"a, b, c">>.
+%% '''
+-spec join(Parts, Separator) -> binary() when
+    Parts :: [binary()],
+    Separator :: binary().
+join([], _Sep) ->
+  <<>>;
+join([Part], _Sep) ->
+  Part;
+join(List, Sep) ->
+  lists:foldr(
+    fun (A, B) ->
+        case bit_size(B) > 0 of
+          true  -> <<A/binary, Sep/binary, B/binary>>;
+          false -> A
+        end
+    end,
+    <<>>,
+    List
+   ).
 
 %% Local variables:
 %% mode: erlang

--- a/src/tql_either.erl
+++ b/src/tql_either.erl
@@ -12,7 +12,14 @@
 %%% API
 %%%---------------------------------------------------------------------
 
--spec fold([fun((Term) -> Return)])
+%% @doc Fold functions into a value.
+%%
+%% The first function is expected to be a nullary function, producing
+%% either an `{ok, V}', `{error, E}' or a plain term value. If the
+%% result is an `{ok, V}' or plain term, the resulting value is fed to
+%% the next function, and so on. As soon as an `{error, E}' tuple is
+%% encountered, the resulting error tuple is returned.
+-spec fold([fun((Term) -> Return), ...])
           -> {ok, Term} | {error, Error}
                when Term   :: term()
                   , Error  :: term()
@@ -20,6 +27,11 @@
 fold([Head | Tail]) ->
   fold(Head(), Tail).
 
+%% @doc Fold over a term with a list of functions.
+%%
+%% Much like `tql_either:fold/1' except the first function is called
+%% with the given value. If the given list of functions is empty,
+%% returns `{ok, V}' where `V' is the given value.
 -spec fold(term(), [fun((Term) -> Return)])
           -> {ok, Term} | {error, Error}
                when Term   :: term()
@@ -29,6 +41,11 @@ fold(Init, Fs) when is_list(Fs) ->
   Result = lists:foldl(fun fold_handle/2, Init, Fs),
   fold_create(Result).
 
+%% @doc Combine a list of result tuples.
+%%
+%% This will result in either an `{error, E}' if any of the supplied
+%% tuples is an error, or `{ok, [V]}' with all the ok-values sequenced
+%% into a list.
 -spec sequence([{error, term()} | {ok, term()}])
               -> {error, term()} | {ok, [term()]}.
 sequence(Eithers) ->
@@ -41,12 +58,14 @@ sequence(Eithers) ->
       {error, Failure}
   end, {ok, []}, Eithers).
 
+%% @doc Check whether the given result tuple is of the form `{ok, V}'.
 -spec is_ok({ok, term()} | {error, term()}) -> boolean().
 is_ok({ok, _}) ->
   true;
 is_ok({error, _}) ->
   false.
 
+%% @doc Check whether the given result tuple is of the form `{error, E}'.
 -spec is_error({ok, term()} | {error, term()}) -> boolean().
 is_error({ok, _}) ->
   false;

--- a/src/tql_either.erl
+++ b/src/tql_either.erl
@@ -1,42 +1,38 @@
 -module(tql_either).
 
 %% API exports
--export([ fold/1
-        , fold/2
+-export([ fold/2
         , sequence/1
         , is_ok/1
         , is_error/1
         ]).
 
+-type either(Term, Error) :: {ok, Term} | {error, Error}.
+
+-export_types([ either/2
+              ]).
+
 %%%---------------------------------------------------------------------
 %%% API
 %%%---------------------------------------------------------------------
 
-%% @doc Fold functions into a value.
-%%
-%% The first function is expected to be a nullary function, producing
-%% either an `{ok, V}', `{error, E}' or a plain term value. If the
-%% result is an `{ok, V}' or plain term, the resulting value is fed to
-%% the next function, and so on. As soon as an `{error, E}' tuple is
-%% encountered, the resulting error tuple is returned.
--spec fold([fun((Term) -> Return), ...])
-          -> {ok, Term} | {error, Error}
-               when Term   :: term()
-                  , Error  :: term()
-                  , Return :: Term | {ok, Term} | {error, Error}.
-fold([Head | Tail]) ->
-  fold(Head(), Tail).
 
 %% @doc Fold over a term with a list of functions.
 %%
-%% Much like `tql_either:fold/1' except the first function is called
-%% with the given value. If the given list of functions is empty,
-%% returns `{ok, V}' where `V' is the given value.
--spec fold(term(), [fun((Term) -> Return)])
-          -> {ok, Term} | {error, Error}
-               when Term   :: term()
-                  , Error  :: term()
-                  , Return :: Term | {ok, Term} | {error, Error}.
+%% The first function in the list is called with the initial value, and
+%% expected to produce either an {@type either(NewValue, Error)} or a bare
+%% `NewValue'. If the produced value is an `{ok, NewValue}' tuple, the
+%% next function is called with `NewValue' as its input. If the produced
+%% value is a bare `NewValue', the next function is called with that
+%% value as its input. If the produced value is an error, processing
+%% stops and returns that `{error, E}' tuple.
+%%
+%% Note that this function will always produce a tuple, so if the final
+%% function produces a bare value, this will be wrapped in a tuple, too.
+-spec fold(term(), [fun((Term) -> Return)]) -> either(Term, Error) when
+    Term   :: term(),
+    Error  :: term(),
+    Return :: either(Term, Error) | Term.
 fold(Init, Fs) when is_list(Fs) ->
   Result = lists:foldl(fun fold_handle/2, Init, Fs),
   fold_create(Result).
@@ -46,8 +42,9 @@ fold(Init, Fs) when is_list(Fs) ->
 %% This will result in either an `{error, E}' if any of the supplied
 %% tuples is an error, or `{ok, [V]}' with all the ok-values sequenced
 %% into a list.
--spec sequence([{error, term()} | {ok, term()}])
-              -> {error, term()} | {ok, [term()]}.
+-spec sequence([either(Term, Error)]) -> either([Term], Error) when
+    Term  :: term(),
+    Error :: term().
 sequence(Eithers) ->
   lists:foldr(fun
     ({ok, Success}, {ok, Successes}) ->
@@ -59,14 +56,14 @@ sequence(Eithers) ->
   end, {ok, []}, Eithers).
 
 %% @doc Check whether the given result tuple is of the form `{ok, V}'.
--spec is_ok({ok, term()} | {error, term()}) -> boolean().
+-spec is_ok(either(T :: term(), E :: term())) -> boolean().
 is_ok({ok, _}) ->
   true;
 is_ok({error, _}) ->
   false.
 
 %% @doc Check whether the given result tuple is of the form `{error, E}'.
--spec is_error({ok, term()} | {error, term()}) -> boolean().
+-spec is_error(either(T :: term(), E :: term())) -> boolean().
 is_error({ok, _}) ->
   false;
 is_error({error, _}) ->
@@ -76,11 +73,10 @@ is_error({error, _}) ->
 %%% Internal functions
 %%%-----------------------------------------------------------------------------
 
--spec fold_handle(fun((Term) -> Return), Return)
-                 -> {ok, Return} | Return | {error, Error}
-                      when Term   :: term()
-                         , Error  :: term()
-                         , Return :: Term | {ok, Term} | {error, Error}.
+-spec fold_handle(fun((Term) -> Return), Return) -> Return when 
+    Term   :: term(),
+    Error  :: term(),
+    Return :: either(Term, Error) | Term.
 fold_handle(F, {ok, Value}) ->
   F(Value);
 fold_handle(_, {error, Reason}) ->
@@ -88,8 +84,9 @@ fold_handle(_, {error, Reason}) ->
 fold_handle(F, Value) ->
   F(Value).
 
--spec fold_create({error, term()} | {ok, term()} | term()) ->
-  {error, term()} | {ok, term()}.
+-spec fold_create(either(Term, Error) | Term) -> either(Term, Error) when
+    Term  :: term(),
+    Error :: term().
 fold_create({error, Reason}) ->
   {error, Reason};
 fold_create({ok, Value}) ->

--- a/src/tql_fun.erl
+++ b/src/tql_fun.erl
@@ -14,35 +14,61 @@
 %%% API
 %%%---------------------------------------------------------------------
 
+%% @doc Compose many functions.
+%%
+%% Given inputs `[F1, F2, ..., Fn]', returns <code>F1 &#8728; F2 &#8728;
+%% ... &#8728; Fn</code>. Note that function composition is associative,
+%% but not commutative. As such, keep in mind that functions are
+%% executed last to first.
+-spec compose([Fun]) -> Fun when Fun :: fun ((A :: term()) -> B :: term()).
 compose(Fs) when is_list(Fs) ->
   lists:foldr(fun compose/2, fun tql:id/1, Fs).
 
+%% @doc Compose 2 functions.
+%%
+%% Given functions `F' and `G', returns a <code>F &#8728; G</code>.
+%%
+%% ```
+%%    F = fun (X) -> X * 2 end,
+%%    G = fun (X) -> X + 1 end,
+%%    H1 = compose(F, G),
+%%    H2 = compose(G, F),
+%%    10 = H1(4),
+%%    9 = H2(4).
+%% '''
+-spec compose(fun((A) -> B), fun((B) -> C)) -> fun ((A) -> C).
 compose(F, G) ->
   fun (X) -> F(G(X)) end.
 
+%% @doc Compose a bunch of predicates using logical conjunction.
+%%
+%% For any given `X', the resulting function will return `true' if and
+%% only if all of the specified functions would return `true' for that
+%% same input. Beware vacuous truths: if the list of predicates is
+%% empty, "all" predicates return `true'.
 -spec all([fun ((A) -> boolean())]) -> fun ((A) -> boolean()).
 all(Fs) ->
   fun (X) -> tql_lists:all(sequence(Fs, X)) end.
 
+%% @doc Compose a bunch of predicates using logical disjunction.
+%%
+%% For any given `X', the resulting function will return `true' if at
+%% least one of the specified predicates would return `true'.
 -spec any([fun ((A) -> boolean())]) -> fun ((A) -> boolean()).
 any(Fs) ->
   fun (X) -> tql_lists:any(sequence(Fs, X)) end.
 
+%% @doc Logical negation for a predicate.
 -spec negate(fun ((A) -> boolean())) -> fun ((A) -> boolean()).
 negate(F) ->
   fun (X) -> not F(X) end.
 
+%% @doc Given a list of functions and an input, return a list where each
+%% element represents the output of running the matching function on the
+%% input.
+-spec sequence([Fun], A) -> [B] when Fun :: fun ((A) -> B).
 sequence(Fs, X) ->
-  sequence(Fs, X, []).
-
-%%%---------------------------------------------------------------------
-%%% Internal functions
-%%%---------------------------------------------------------------------
-
-sequence([], _, Ys) ->
-  lists:reverse(Ys);
-sequence([F | Fs], X, Ys) ->
-  sequence(Fs, X, [F(X) | Ys]).
+  lists:map(fun(F) -> F(X) end, Fs).
 
 %% Local variables:
 %% mode: erlang

--- a/src/tql_lists.erl
+++ b/src/tql_lists.erl
@@ -15,13 +15,13 @@
 %%% API
 %%%---------------------------------------------------------------------
 
-%% @doc Conjuncion of a list of booleans. Returns `true' iff all the
-%% booleans are `true'.
+%% @doc Conjunction of a list of booleans. Returns `true' if and only if
+%% all the booleans are `true'.
 -spec all([boolean()]) -> boolean().
 all(Xs) ->
   lists:all(fun tql:id/1, Xs).
 
-%% @doc Disunjection of a list of booleans. Returns `true' if at least
+%% @doc Disjunction of a list of booleans. Returns `true' if at least
 %% one of the booleans is `true'.
 -spec any([boolean()]) -> boolean().
 any(Xs) ->

--- a/src/tql_lists.erl
+++ b/src/tql_lists.erl
@@ -7,48 +7,48 @@
         , droplast_n/2
         , intersperse/2
         , shuffle/1
-        , some/1
         , take/2
         , uniq/1
-        , zip4/4
-        , zip5/5
         ]).
 
 %%%---------------------------------------------------------------------
 %%% API
 %%%---------------------------------------------------------------------
 
+%% @doc Conjuncion of a list of booleans. Returns `true' iff all the
+%% booleans are `true'.
 -spec all([boolean()]) -> boolean().
 all(Xs) ->
   lists:all(fun tql:id/1, Xs).
 
+%% @doc Disunjection of a list of booleans. Returns `true' if at least
+%% one of the booleans is `true'.
 -spec any([boolean()]) -> boolean().
 any(Xs) ->
   lists:any(fun tql:id/1, Xs).
 
-%% TODO: -spec
-droplast_n(L = [], _) ->
+%% @doc Drops the last `N' entries from the given list.
+-spec droplast_n(N :: non_neg_integer(), [X]) -> [X].
+droplast_n(_, L = []) ->
   L;
-droplast_n(L, 0) ->
+droplast_n(0, L) ->
   L;
-droplast_n(L, N) ->
-  droplast_n(lists:droplast(L), N - 1).
+droplast_n(N, L) ->
+  droplast_n(N - 1, lists:droplast(L)).
 
-%% TODO: -spec
+%% @doc Place the given value between all members of the given list.
+-spec intersperse(X, [X]) -> [X].
 intersperse(_S, L = [_]) ->
   L;
 intersperse(S, [X | Xs]) ->
   [X, S | intersperse(S, Xs)].
 
-%% TODO: -spec
+%% @doc Shuffle a list.
 shuffle(L) ->
   [X || {_, X} <- lists:sort([{rand:uniform(), X} || X <- L])].
 
--spec some([boolean()]) -> boolean().
-some(Xs) ->
-  lists:member(true, Xs).
-
-%% TODO: -spec
+%% @doc Take the first `N' elements from the given list.
+-spec take(N :: non_neg_integer(), [X]) -> [X].
 take(0, _) ->
   [];
 take(_, []) ->
@@ -56,21 +56,13 @@ take(_, []) ->
 take(N, [X | Xs]) ->
   [X | take(N-1, Xs)].
 
+%% @doc Returns only unique elements from the given list, filtering out
+%% duplicates.
+%%
+%% Elements are considered to be different if they do not match (`=:=').
 -spec uniq([A]) -> [A].
 uniq(L) ->
   sets:to_list(sets:from_list(L)).
-
-
-zip4([X | Xs], [Y | Ys], [Z | Zs], [V | Vs]) ->
-  [{X, Y, Z, V} | zip4(Xs, Ys, Zs, Vs)];
-zip4([], [], [], []) ->
-  [].
-
-%% TODO: -spec
-zip5([X | Xs], [Y | Ys], [Z | Zs], [V | Vs], [W | Ws]) ->
-  [{X, Y, Z, V, W} | zip5(Xs, Ys, Zs, Vs, Ws)];
-zip5([], [], [], [], []) ->
-  [].
 
 %% Local variables:
 %% mode: erlang

--- a/src/tql_maps.erl
+++ b/src/tql_maps.erl
@@ -3,8 +3,8 @@
 %% API
 
 -export([ map_values/2
-        , mergeWith/3
-        , mergeWith3/4
+        , merge_with/3
+        , merge_with3/4
         , update_key/3
         ]).
 
@@ -12,12 +12,19 @@
 %%% API
 %%%---------------------------------------------------------------------
 
+%% @doc Map a function over the values of a map.
 -spec map_values(fun((V) -> V), #{K => V}) -> #{K => V}.
 map_values(F, M) ->
   maps:map(fun (_, V) -> F(V) end, M).
 
--spec mergeWith(fun((V, V) -> V), #{K => V}, #{K => V}) -> #{K => V}.
-mergeWith(Combine, M1, M2) ->
+%% @doc Merge 2 maps, using the specificied `Combine' function for identical keys.
+%%
+%% When a key exists in both maps, `Combine' is called with the values
+%% for the first and second map, using the result in the resulting map.
+-spec merge_with(Combine, Map, Map) -> Map when
+    Combine :: fun((V, V) -> V),
+    Map :: #{K :: term() => V}.
+merge_with(Combine, M1, M2) ->
   lists:foldl(
     fun (K, M) ->
         case maps:is_key(K, M) of
@@ -29,11 +36,26 @@ mergeWith(Combine, M1, M2) ->
     maps:keys(M2)
    ).
 
--spec mergeWith3(fun((V, V) -> V), #{K => V}, #{K => V}, #{K => V})
-              -> #{K => V}.
-mergeWith3(Combine, M1, M2, M3) ->
-  mergeWith(Combine, mergeWith(Combine, M1, M2), M3).
+%% @doc Merge 3 maps, using the specified `Combine' function for clashing keys.
+%%
+%% If a key exists in all three maps, `Combine' will first be called
+%% with the values from the first and second map, then with the result of
+%% that call and the value from the third map.
+-spec merge_with3(Combine, Map, Map, Map) -> Map when
+    Combine :: fun((V, V) -> V),
+    Map :: #{K :: term() => V}.
+merge_with3(Combine, M1, M2, M3) ->
+  merge_with(Combine, merge_with(Combine, M1, M2), M3).
 
+%% @doc Replace a key in a map with another key.
+%%
+%% If the new key already exists, its value will be replaced with the
+%% value that used to be asociated with `OldKey'.
+-spec update_key(OldKey, NewKey, Map) -> UpdatedMap when
+    OldKey :: term(),
+    NewKey :: term(),
+    Map :: #{OldKey := Value :: term()},
+    UpdatedMap :: #{NewKey := Value :: term()}.
 update_key(Old, New, M) ->
   V = maps:get(Old, M),
   M2 = maps:remove(Old, M),

--- a/src/tql_sets.erl
+++ b/src/tql_sets.erl
@@ -3,8 +3,8 @@
 %% API
 
 -export([ all/2
-        , equal/2
-        , intersect/2
+        , equals/2
+        , intersects/2
         , is_empty/1
         , map/2
         , symmetric_difference/2
@@ -14,22 +14,34 @@
 %%% API
 %%%---------------------------------------------------------------------
 
+%% @doc Check if all entries of a set satisfy a predicate.
+%%
+%% Beware vacuous truths: if the given set is empty, all entries match
+%% the predicate and the result will be `true'.
 -spec all(fun((T) -> boolean()), sets:set(T)) -> boolean().
 all(Pred, Set) ->
   lists:all(Pred, sets:to_list(Set)).
 
--spec equal(sets:set(), sets:set()) -> boolean().
-equal(Set1, Set2) ->
+%% @doc Check if 2 sets contain the same elements.
+-spec equals(sets:set(T), sets:set(T)) -> boolean().
+equals(Set1, Set2) ->
   sets:is_subset(Set1, Set2) andalso sets:is_subset(Set2, Set1).
 
--spec intersect(sets:set(), sets:set()) -> boolean().
-intersect(Set1, Set2) ->
-  sets:size(sets:intersection(Set1, Set2)) > 0.
+%% @doc Check if the given sets have a nonempty intersection.
+-spec intersects(sets:set(T), sets:set(T)) -> boolean().
+intersects(Set1, Set2) ->
+  not is_empty(sets:intersection(Set1, Set2)).
 
--spec is_empty(sets:set()) -> boolean().
+%% @doc Check if the given set is empty.
+-spec is_empty(sets:set(T :: term())) -> boolean().
 is_empty(Set) ->
   sets:size(Set) == 0.
 
+%% @doc Map a function over the elements of a set.
+%%
+%% Note that if some of the values in the given set map to the same
+%% value, the resulting set may be smaller as it will only contain unique
+%% elements.
 -spec map(fun((T1) -> T2), sets:set(T1)) -> sets:set(T2).
 map(Fun, Set) ->
   sets:fold( fun(X, Acc) -> sets:add_element(Fun(X), Acc) end
@@ -37,7 +49,10 @@ map(Fun, Set) ->
            , Set
            ).
 
--spec symmetric_difference(sets:set(), sets:set()) -> sets:set().
+%% @doc Calculates the symmetric difference of 2 sets.
+%%
+%% In other words, find all the elements that do not exist in both sets.
+-spec symmetric_difference(sets:set(T), sets:set(T)) -> sets:set(T).
 symmetric_difference(Set1, Set2) ->
   sets:union(sets:subtract(Set1, Set2), sets:subtract(Set2, Set1)).
 

--- a/test/tql_either_SUITE.erl
+++ b/test/tql_either_SUITE.erl
@@ -8,7 +8,6 @@
         , test_fold1/1
         , test_fold2/1
         , test_fold3/1
-        , test_fold4/1
         , test_sequence1/1
         , test_sequence2/1
         , test_sequence3/1
@@ -18,7 +17,6 @@ all() ->
   [ test_fold1
   , test_fold2
   , test_fold3
-  , test_fold4
   , test_sequence1
   , test_sequence2
   , test_sequence3
@@ -29,14 +27,6 @@ all() ->
 %%%---------------------------------------------------------------------
 
 test_fold1(_Config) ->
-  Result = tql_either:fold([ fun initiate_map/0
-                           , fun(X) -> add_foo(X, 1) end
-                           , fun increment_foo/1
-                           , fun maps:to_list/1
-                           ]),
-  {ok, [{foo, 2}]} = Result.
-
-test_fold2(_Config) ->
   Result = tql_either:fold( #{}
                           , [ fun(X) -> add_foo(X, 1) end
                             , fun increment_foo/1
@@ -45,7 +35,7 @@ test_fold2(_Config) ->
   {ok, [{foo, 2}]} = Result.
 
 
-test_fold3(_Config) ->
+test_fold2(_Config) ->
   Result = tql_either:fold( #{foo => 2}
                           , [ fun(X) -> add_foo(X, 1) end
                             , fun increment_foo/1
@@ -53,7 +43,7 @@ test_fold3(_Config) ->
                             ]),
   {error, foo_already_set} = Result.
 
-test_fold4(_Config) ->
+test_fold3(_Config) ->
   Result = tql_either:fold( #{}
                           , [ fun(X) -> add_foo(X, "BAR") end
                             , fun increment_foo/1
@@ -64,9 +54,9 @@ test_fold4(_Config) ->
 
 test_sequence1(_Config) ->
   Result = tql_either:sequence([ {ok, true}
-                              , {ok, 1}
-                              , {ok, "foobar"}
-                              ]),
+                               , {ok, 1}
+                               , {ok, "foobar"}
+                               ]),
   {ok, [true, 1, "foobar"]} = Result.
 
 test_sequence2(_Config) ->
@@ -89,9 +79,6 @@ test_sequence3(_Config) ->
 %%% Internal functions
 %%%-----------------------------------------------------------------------------
 
-
-initiate_map() ->
-  #{}.
 
 add_foo(#{ foo := _ }, _Value) ->
   {error, foo_already_set};

--- a/test/tql_lists_SUITE.erl
+++ b/test/tql_lists_SUITE.erl
@@ -6,14 +6,14 @@
 -export([ all/0
           %% Tests
         , all_/1
-        , some/1
+        , any/1
         , uniq/1
         ]
        ).
 
 all() ->
   [ all_
-  , some
+  , any
   , uniq
   ].
 
@@ -32,12 +32,12 @@ all_(_Config) ->
           ),
   ok.
 
-some(_Config) ->
+any(_Config) ->
   true = proper:quickcheck(
            ?FORALL( L
                   , list(boolean())
                   , ?IMPLIES(lists:member(true, L)
-                            , tql_lists:some(L)
+                            , tql_lists:any(L)
                             )
                   )
           ),

--- a/test/tql_maps_SUITE.erl
+++ b/test/tql_maps_SUITE.erl
@@ -5,33 +5,33 @@
 
 -export([ all/0
           %% Tests
-        , mergeWith/1
-        , mergeWithHasAllKeys/1
-        , mergeWithCombinesValues/1
-        , mergeWith3/1
+        , merge_with/1
+        , merge_with_has_all_keys/1
+        , merge_with_combines_values/1
+        , merge_with3/1
         ]
        ).
 
 all() ->
-  [ mergeWithHasAllKeys
-  , mergeWithCombinesValues
-  , mergeWith3
+  [ merge_with_has_all_keys
+  , merge_with_combines_values
+  , merge_with3
   ].
 
 %%%---------------------------------------------------------------------
 %%% Tests
 %%%---------------------------------------------------------------------
 
-mergeWith(_Config) ->
+merge_with(_Config) ->
   M1 = #{a => 1, b => 2},
   M2 = #{a => 3, c => 3},
-  M = tql_maps:mergeWith(fun (X, Y) -> X + Y end, M1, M2),
+  M = tql_maps:merge_with(fun (X, Y) -> X + Y end, M1, M2),
   4 = maps:get(a, M),
   2 = maps:get(b, M),
   3 = maps:get(c, M),
   ok.
 
-mergeWithHasAllKeys(_Config) ->
+merge_with_has_all_keys(_Config) ->
   true =
     proper:quickcheck(
       proper:forall(
@@ -39,19 +39,19 @@ mergeWithHasAllKeys(_Config) ->
               , random_map(string(), integer())
               ]),
         fun({Map1, Map2}) ->
-            Map = tql_maps:mergeWith(
+            Map = tql_maps:merge_with(
                     fun(X, Y) -> X + Y end, Map1, Map2
                    ),
             Keys1 = sets:from_list(maps:keys(Map1)),
             Keys2 = sets:from_list(maps:keys(Map2)),
             Keys = sets:from_list(maps:keys(Map)),
-            tql_sets:equal(sets:union(Keys1, Keys2), Keys)
+            tql_sets:equals(sets:union(Keys1, Keys2), Keys)
         end
        )
      ),
   ok.
 
-mergeWithCombinesValues(_Config) ->
+merge_with_combines_values(_Config) ->
   F = fun(X,Y) -> X + Y end,
   true =
     proper:quickcheck(
@@ -60,7 +60,7 @@ mergeWithCombinesValues(_Config) ->
               , random_map(string(), integer())
               ]),
         fun({M1, M2}) ->
-            M = tql_maps:mergeWith(F, M1, M2),
+            M = tql_maps:merge_with(F, M1, M2),
             lists:foldl(
               fun(K, Acc) ->
                   V1 = maps:get(K, M1, 0),
@@ -74,11 +74,11 @@ mergeWithCombinesValues(_Config) ->
         end)
      ).
 
-mergeWith3(_Config) ->
+merge_with3(_Config) ->
   M1 = #{a => 1, b => 2},
   M2 = #{a => 3, c => 3},
   M3 = #{a => 1, c => 1},
-  M = tql_maps:mergeWith3(fun (X, Y) -> X + Y end, M1, M2, M3),
+  M = tql_maps:merge_with3(fun (X, Y) -> X + Y end, M1, M2, M3),
   5 = maps:get(a, M),
   2 = maps:get(b, M),
   4 = maps:get(c, M),


### PR DESCRIPTION
Ended up doing a little more than adding specs.

All functions are documented and have typespecs.

## Removed
- `tql:to_hex/1` (duplicate of `tql_bin:to_hex/1`)
- `tql_lists:some/1` (duplicate of `tql_lists:any/1`)
- `tql_lists:zip4/4` (can be replaced by a better implementation if required)
- `tql_lists:zip5/5` (can be replaced by a better implementation if required)


## Renamed
- `tql:binary_join/1` -> `tql_bin:join/1`
- `tql_maps:mergeWith/3` -> `tql_maps:merge_with/3`
- `tql_maps:mergeWith3/4` -> `tql_maps:merge_with3/4`
- `tql_sets:equal/2` -> `tql_sets:equals/2`
- `tql_sets:intersect/2` -> `tql_sets:intersects/2`

## Changed
- `tql_lists:droplast_n/2` -> swapped argument order for consistency with `tql_lists:take/2` and general sanity.