### PR TITLE
Add comparison tools

### DIFF
--- a/src/tql_compare.erl
+++ b/src/tql_compare.erl
@@ -13,16 +13,24 @@
 -type comparator(T) :: fun ((T, T) -> boolean()).
 -type order() :: ascending | descending.
 
+-export_types([ comparator/1
+              , order/0
+              ]).
+
 %%%---------------------------------------------------------------------
 %%% API
 %%%---------------------------------------------------------------------
 
+%% @equiv by(F, ascending)
 -spec by(fun ((A) -> B)) -> comparator(A) when
     A :: term(),
     B :: term().
-by(X) ->
-  by(X, ascending).
+by(F) ->
+  by(F, ascending).
 
+%% @doc Creates a comparison function (`comparator(A)') compatible with
+%% `lists:sort/2', using the extracted term to sort in the given
+%% direction.
 -spec by(fun ((A) -> B), order()) -> comparator(A) when
     A :: term(),
     B :: term().
@@ -31,24 +39,36 @@ by(Extractor, ascending) ->
 by(Extractor, descending) ->
   fun (X, Y) -> Extractor(Y) =< Extractor(X) end.
 
+%% @doc Reverses the order in which elements are sorted by a comparator.
 -spec reverse(comparator(T)) -> comparator(T) when T :: term().
 reverse(Comparator) ->
   fun (X, Y) -> Comparator(Y, X) end.
 
+%% @equiv by_prop(Key, ascending)
 -spec by_prop(Key :: term()) -> comparator(map()).
 by_prop(Key) ->
   by_prop(Key, ascending).
 
+%% @doc Creates a comparator for maps, sorting by a given property, in
+%% the given direction.
 -spec by_prop(Key :: term(), order()) -> comparator(map()).
 by_prop(Key, Order) ->
   by(fun (Map) -> maps:get(Key, Map) end, Order).
 
+%% @doc Creates a comparator for maps, sorting by the given property and
+%% using the `Default' as fallback value, to sort in the provided
+%% direction.
 -spec by_prop(Key, Default, order()) -> comparator(map()) when
     Key     :: term(),
     Default :: term().
 by_prop(Key, Default, Order) ->
   by(fun (Map) -> maps:get(Key, Map, Default) end, Order).
 
+%% @doc Composes multiple comparators together.
+%%
+%% Fallthrough happens when 2 items are considered equivalent _according
+%% to the comparators_. Specifically, this means when `Compare(A, B) ==
+%% Compare(B, A)'.
 -spec concat([Comp, ...]) -> Comp when
     Comp :: comparator(T :: term()).
 concat(Comparators) ->

--- a/src/tql_compare.erl
+++ b/src/tql_compare.erl
@@ -1,0 +1,83 @@
+-module(tql_compare).
+
+%% API exports
+-export([ by/1
+        , by/2
+        , by_prop/1
+        , by_prop/2
+        , by_prop/3
+        , concat/1
+        , reverse/1
+        ]).
+
+-type comparator(T) :: fun ((T, T) -> boolean()).
+-type order() :: ascending | descending.
+
+%%%---------------------------------------------------------------------
+%%% API
+%%%---------------------------------------------------------------------
+
+-spec by(fun ((A) -> B)) -> comparator(A) when
+    A :: term(),
+    B :: term().
+by(X) ->
+  by(X, ascending).
+
+-spec by(fun ((A) -> B), order()) -> comparator(A) when
+    A :: term(),
+    B :: term().
+by(Extractor, ascending) ->
+  fun (X, Y) -> Extractor(X) =< Extractor(Y) end;
+by(Extractor, descending) ->
+  fun (X, Y) -> Extractor(Y) =< Extractor(X) end.
+
+-spec reverse(comparator(T)) -> comparator(T) when T :: term().
+reverse(Comparator) ->
+  fun (X, Y) -> Comparator(Y, X) end.
+
+-spec by_prop(Key :: term()) -> comparator(map()).
+by_prop(Key) ->
+  by_prop(Key, ascending).
+
+-spec by_prop(Key :: term(), order()) -> comparator(map()).
+by_prop(Key, Order) ->
+  by(fun (Map) -> maps:get(Key, Map) end, Order).
+
+-spec by_prop(Key, Default, order()) -> comparator(map()) when
+    Key     :: term(),
+    Default :: term().
+by_prop(Key, Default, Order) ->
+  by(fun (Map) -> maps:get(Key, Map, Default) end, Order).
+
+-spec concat([Comp, ...]) -> Comp when
+    Comp :: comparator(T :: term()).
+concat(Comparators) ->
+  fun (X, Y) ->
+      concat_help(X, Y, Comparators)
+  end.
+
+%%%---------------------------------------------------------------------
+%%% Internal functions
+%%%---------------------------------------------------------------------
+
+-spec concat_help(X, Y, [Comp, ...]) -> boolean() when
+    X    :: T,
+    Y    :: T,
+    Comp :: comparator(T),
+    T    :: term().
+concat_help(X, Y, [Comp]) ->
+  Comp(X, Y);
+concat_help(X, Y, [Comp | Rest]) ->
+  OtherDir = Comp(Y, X),
+  case Comp(X, Y) of
+    OtherDir -> concat_help(X, Y, Rest);
+    Res      -> Res
+  end.
+
+%% Local variables:
+%% mode: erlang
+%% erlang-indent-level: 2
+%% indent-tabs-mode: nil
+%% fill-column: 72
+%% coding: latin-1
+%% End:

--- a/test/tql_compare_SUITE.erl
+++ b/test/tql_compare_SUITE.erl
@@ -1,0 +1,114 @@
+-module(tql_compare_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("proper/include/proper.hrl").
+
+-export([ all/0 ]).
+
+-export([ properties/1
+        , by/1
+        , by_prop/1
+        , concat/1
+        ]).
+
+all() ->
+    [ properties
+    , by
+    , by_prop
+    , concat
+    ].
+
+%%%---------------------------------------------------------------------
+%%% Tests
+%%%---------------------------------------------------------------------
+
+properties(_Config) ->
+  true =
+    proper:quickcheck(
+      proper:forall( list(term())
+                   , fun prop_by_id_is_noop/1
+                   )
+     ),
+  true =
+    proper:quickcheck(
+      proper:forall( list(term())
+                   , fun prop_reverse_reverse_is_id/1
+                   )
+     ),
+  true = 
+    proper:quickcheck(
+     proper:forall( list(term())
+                  , fun prop_desc_is_reverse/1
+                  )
+     ),
+  ok.
+
+by(_Config) ->
+  F = fun ({_, V}) -> V end,
+  Xs = [{foo, 20}, {bar, 40}, {baz, 10}, {etc, 30}],
+  Ys = [{baz, 10}, {foo, 20}, {etc, 30}, {bar, 40}],
+  Ry = lists:reverse(Ys),
+  Ys = lists:sort(tql_compare:by(F, ascending), Xs),
+  Ry = lists:sort(tql_compare:by(F, descending), Xs),
+  ok.
+
+by_prop(_Config) ->
+  Xs = [ #{a => 0, b => 10}
+       , #{a => 1, b => 9}
+       , #{a => 2, b => 8}
+       , #{a => 3, b => 7}
+       ],
+  Ys = lists:reverse(Xs),
+  Xs = lists:sort(tql_compare:by_prop(a), Xs),
+  Ys = lists:sort(tql_compare:by_prop(b), Xs),
+  ok.
+
+concat(_Config) ->
+  Xs = [ #{a => 0, b => 0}
+       , #{a => 1, b => 2}
+       , #{a => 3}
+       , #{a => 1, b => 1}
+       , #{a => 2}
+       , #{a => 0, b => 3}
+       , #{a => 3, b => 5}
+       ],
+  Ys = [ #{a => 0, b => 3}
+       , #{a => 0, b => 0}
+       , #{a => 1, b => 2}
+       , #{a => 1, b => 1}
+       , #{a => 2}
+       , #{a => 3, b => 5}
+       , #{a => 3}
+       ],
+  ByY = tql_compare:by_prop(b, 0, descending),
+  ByX = tql_compare:by_prop(a),
+  Comp = tql_compare:concat([ByX, ByY]),
+  Ys = lists:sort(Comp, Xs),
+  ok.
+
+%%%---------------------------------------------------------------------
+%%% Properties
+%%%---------------------------------------------------------------------
+
+prop_desc_is_reverse(Xs) ->
+  Comp = tql_compare:by(fun tql:id/1),
+  Rev = tql_compare:reverse(Comp),
+  Desc = tql_compare:by(fun tql:id/1, descending),
+  lists:sort(Desc, Xs) =:= lists:sort(Rev, Xs).
+
+prop_by_id_is_noop(Xs) ->
+  lists:sort(Xs) =:= lists:sort(tql_compare:by(fun tql:id/1), Xs).
+
+prop_reverse_reverse_is_id(Xs) ->
+  Comp = tql_compare:by(fun tql:id/1),
+  Rev1 = tql_compare:reverse(Comp),
+  Rev2 = tql_compare:reverse(Rev1),
+  lists:sort(Xs) =:= lists:sort(Rev2, Xs).
+
+%% Local variables:
+%% mode: erlang
+%% erlang-indent-level: 2
+%% indent-tabs-mode: nil
+%% fill-column: 72
+%% coding: latin-1
+%% End:


### PR DESCRIPTION
I've seen a few use-cases in the TruQu codebase where something like this would clean things up.

# Todo:

- [x] Document