### PR TITLE
Add a `with_default/2` function

### DIFF
--- a/src/tql_either.erl
+++ b/src/tql_either.erl
@@ -6,6 +6,7 @@
         , is_ok/1
         , is_error/1
         , from_bool/3
+        , with_default/2
         , oks/1
         ]).
 
@@ -83,6 +84,16 @@ from_bool(Result, _, true) ->
 from_bool(_, Reason, false) ->
   {error, Reason}.
 
+-spec with_default(either(Result, Reason), Default) -> Result | Default when
+    Result  :: term(),
+    Reason  :: term(),
+    Default :: term().
+with_default({ok, Value}, _) ->
+  Value;
+with_default({error, _}, Default) ->
+  Default.
+
+%% @doc Collect the `ok' values from a list of result tuples.
 -spec oks([either(Result, Reason)]) -> [Result] when
     Result :: term(),
     Reason :: term().

--- a/test/tql_either_SUITE.erl
+++ b/test/tql_either_SUITE.erl
@@ -12,6 +12,7 @@
         , test_sequence2/1
         , test_sequence3/1
         , test_from_bool/1
+        , test_with_default/1
         , test_oks/1
         ]).
 
@@ -23,6 +24,7 @@ all() ->
   , test_sequence2
   , test_sequence3
   , test_from_bool
+  , test_with_default
   , test_oks
   ].
 
@@ -83,6 +85,11 @@ test_from_bool(_Config) ->
   Result2 = tql_either:from_bool(authorized, unauthorized, false),
   {ok, authorized} = Result1,
   {error, unauthorized} = Result2.
+
+test_with_default(_Config) ->
+  Result1 = tql_either:with_default({ok, <<"good">>}, <<"bad">>),
+  Result2 = tql_either:with_default({error, <<"bad">>}, <<"good">>),
+  Result1 = Result2 = <<"good">>.
 
 test_oks(_Config) ->
   Result1 = tql_either:oks([{ok, 1}, {error, 2}, {ok, 3}]),


### PR DESCRIPTION
When dealing with `either(V, E)` types, one fairly frequently wants to convert
it to a bare term, using a default value in case the result tuple is an `{error,
_}`. Using `tql_either:with_default(Result, Default)`, this use case becomes a
little less fragile.

```erlang
case Result of
  {ok, V} ->
    V;
  {error, _} ->
    SomeDefault
end
```

now becomes:

```erlang
tql_either:with_default(Result, SomeDefault)
```