### PR TITLE
Add tql_either:traverse/2

### DIFF
--- a/test/tql_either_SUITE.erl
+++ b/test/tql_either_SUITE.erl
@@ -11,6 +11,7 @@
         , test_sequence1/1
         , test_sequence2/1
         , test_sequence3/1
+        , test_traverse/1
         , test_from_bool/1
         , test_and/1
         , test_with_default/1
@@ -24,6 +25,7 @@ all() ->
   , test_sequence1
   , test_sequence2
   , test_sequence3
+  , test_traverse
   , test_from_bool
   , test_and
   , test_with_default
@@ -81,6 +83,16 @@ test_sequence3(_Config) ->
                                , {error, ignored}
                                ]),
   {error, not_found} = Result.
+
+test_traverse(_Config) ->
+  F = fun (X) when X >= 0 ->
+          {ok, X * 2};
+          (_) ->
+          {error, negative}
+      end,
+  {ok, []} = tql_either:traverse(F, []),
+  {ok, [2, 4, 6]} = tql_either:traverse(F, [1, 2, 3]),
+  {error, negative} = tql_either:traverse(F, [1, 2, -1]).
 
 test_from_bool(_Config) ->
   Result1 = tql_either:from_bool(authorized, unauthorized, true),


### PR DESCRIPTION
It's reasonably common to want to collect the results of an either-returning
function based on a list of inputs. Something we currently sometimes do in our
codebase is the very silly `tql_either:sequence(lists:map(F, Xs))`.

Why silly? Well, it does way more work that it ought to. Imagine `F` does
something that involves IO like writing to a database. It's pretty silly to go
through all that work when we could just bail out on the first error, with less
code!